### PR TITLE
Workaround the autorest bugs and Fix auth bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
       <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -157,20 +163,20 @@
        <groupId>com.googlecode.addjars-maven-plugin</groupId>
        <artifactId>addjars-maven-plugin</artifactId>
        <version>1.0.5</version>
-          <executions>
-             <execution>
-                <goals>
-                  <goal>add-jars</goal>
-                </goals>
-                <configuration>
-                  <resources>
-                    <resource>
-                      <directory>../extlib</directory>
-                    </resource>
-                 </resources>
-              </configuration>
-           </execution>
-        </executions>
+       <executions>
+         <execution>
+           <goals>
+             <goal>add-jars</goal>
+           </goals>
+           <configuration>
+             <resources>
+               <resource>
+                 <directory>../extlib</directory>
+               </resource>
+             </resources>
+           </configuration>
+         </execution>
+       </executions>
       </plugin>
 
     </plugins>

--- a/src/main/java/com/microsoft/azure/batch/protocol/models/FileGetPropertiesFromComputeNodeHeaders.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/models/FileGetPropertiesFromComputeNodeHeaders.java
@@ -43,13 +43,13 @@ public class FileGetPropertiesFromComputeNodeHeaders {
      * particular, you can pass the ETag to one of the If-Modified-Since,
      * If-Unmodified-Since, If-Match or If-None-Match headers.
      */
-    @JsonProperty(value = "ETag")
+    @JsonProperty(value = "etag")
     private String eTag;
 
     /**
      * The time at which the resource was last modified.
      */
-    @JsonProperty(value = "Last-Modified")
+    @JsonProperty(value = "last-modified")
     private DateTimeRfc1123 lastModified;
 
     /**
@@ -79,13 +79,13 @@ public class FileGetPropertiesFromComputeNodeHeaders {
     /**
      * The content type of the file.
      */
-    @JsonProperty(value = "Content-Type")
+    @JsonProperty(value = "content-type")
     private String contentType;
 
     /**
      * The length of the file.
      */
-    @JsonProperty(value = "Content-Length")
+    @JsonProperty(value = "content-length")
     private Long contentLength;
 
     /**

--- a/src/main/java/com/microsoft/azure/batch/protocol/models/FileGetPropertiesFromTaskHeaders.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/models/FileGetPropertiesFromTaskHeaders.java
@@ -43,13 +43,13 @@ public class FileGetPropertiesFromTaskHeaders {
      * particular, you can pass the ETag to one of the If-Modified-Since,
      * If-Unmodified-Since, If-Match or If-None-Match headers.
      */
-    @JsonProperty(value = "ETag")
+    @JsonProperty(value = "etag")
     private String eTag;
 
     /**
      * The time at which the resource was last modified.
      */
-    @JsonProperty(value = "Last-Modified")
+    @JsonProperty(value = "last-modified")
     private DateTimeRfc1123 lastModified;
 
     /**
@@ -79,13 +79,13 @@ public class FileGetPropertiesFromTaskHeaders {
     /**
      * The content type of the file.
      */
-    @JsonProperty(value = "Content-Type")
+    @JsonProperty(value = "content-type")
     private String contentType;
 
     /**
      * The length of the file.
      */
-    @JsonProperty(value = "Content-Length")
+    @JsonProperty(value = "content-length")
     private Long contentLength;
 
     /**

--- a/src/test/java/com/microsoft/azure/batch/FileTests.java
+++ b/src/test/java/com/microsoft/azure/batch/FileTests.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for
+ * license information.
+ */
+
+package com.microsoft.azure.batch;
+
+import com.microsoft.azure.batch.protocol.models.*;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.apache.commons.io.IOUtils;
+import rx.exceptions.Exceptions;
+import rx.functions.Func1;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+public class FileTests extends BatchTestBase {
+    static CloudPool livePool;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        createClient(AuthMode.SharedKey);
+        String poolId = getStringWithUserNamePrefix("-testpool");
+        livePool = createIfNotExistPaaSPool(poolId);
+        Assert.assertNotNull(livePool);
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        try {
+            //batchClient.poolOperations().deletePool(livePool.id());
+        }
+        catch (Exception e) {
+            // ignore any clean up exception
+        }
+    }
+
+    @Test
+    public void canReadFromTaskFile() throws Exception {
+        // CREATE
+        String jobId = getStringWithUserNamePrefix("-Job-" + (new Date()).toString().replace(' ', '-').replace(':', '-').replace('.', '-'));
+        String taskId = "mytask";
+        Duration TASK_COMPLETE_TIMEOUT = Duration.ofMinutes(1);
+
+        try {
+
+            PoolInformation poolInfo = new PoolInformation();
+            poolInfo.withPoolId(livePool.id());
+            batchClient.jobOperations().createJob(jobId, poolInfo);
+
+            TaskAddParameter taskToAdd = new TaskAddParameter();
+            taskToAdd.withId(taskId)
+                    .withCommandLine("cmd /c echo hello");
+            batchClient.taskOperations().createTask(jobId, taskToAdd);
+
+            if (waitForTasksToComplete(batchClient, jobId, TASK_COMPLETE_TIMEOUT)) {
+                List<NodeFile> files = batchClient.fileOperations().listFilesFromTask(jobId, taskId);
+                boolean found = false;
+                for (NodeFile f : files) {
+                    if (f.name().equals("stdout.txt")) {
+                        found = true;
+                        break;
+                    }
+                }
+                Assert.assertTrue(found);
+
+                InputStream stream = batchClient.fileOperations().getFileFromTask(jobId, taskId, "stdout.txt");
+                String fileContent = IOUtils.toString(stream, "UTF-8");
+                Assert.assertEquals(fileContent, "hello\r\n");
+                stream.close();
+
+                String output = batchClient.protocolLayer().files().getFromTaskAsync(jobId, taskId, "stdout.txt").map(new Func1<InputStream, String>() {
+                    @Override
+                    public String call(InputStream input) {
+                        try {
+                            return IOUtils.toString(input, "UTF-8");
+                        } catch (IOException e) {
+                            throw Exceptions.propagate(e);
+                        }
+                    }
+                }).toBlocking().single();
+                Assert.assertEquals(fileContent, "hello\r\n");
+
+                FileProperties properties = batchClient.fileOperations().getFilePropertiesFromTask(jobId, taskId, "stdout.txt");
+                Assert.assertEquals(7, properties.contentLength());
+            } else {
+                throw new TimeoutException("Task did not complete within the specified timeout");
+            }
+        }
+        finally {
+            try {
+                batchClient.jobOperations().deleteJob(jobId);
+            }
+            catch (Exception e) {
+                // Ignore here
+            }
+        }
+    }
+
+    @Test
+    public void canReadFromNode() throws Exception {
+        // CREATE
+        String jobId = getStringWithUserNamePrefix("-Job-" + (new Date()).toString().replace(' ', '-').replace(':', '-').replace('.', '-'));
+        String taskId = "mytask";
+        Duration TASK_COMPLETE_TIMEOUT = Duration.ofMinutes(1);
+
+        try {
+            PoolInformation poolInfo = new PoolInformation();
+            poolInfo.withPoolId(livePool.id());
+            batchClient.jobOperations().createJob(jobId, poolInfo);
+
+            TaskAddParameter taskToAdd = new TaskAddParameter();
+            taskToAdd.withId(taskId)
+                    .withCommandLine("cmd /c echo hello");
+            batchClient.taskOperations().createTask(jobId, taskToAdd);
+
+            if (waitForTasksToComplete(batchClient, jobId, TASK_COMPLETE_TIMEOUT)) {
+                CloudTask task = batchClient.taskOperations().getTask(jobId, taskId);
+                String nodeId = task.nodeInfo().nodeId();
+
+                List<NodeFile> files = batchClient.fileOperations().listFilesFromComputeNode(livePool.id(), nodeId, true, null);
+                String fileName = null;
+                for (NodeFile f : files) {
+                    if (f.name().endsWith("stdout.txt")) {
+                        fileName = f.name();
+                        break;
+                    }
+                }
+                Assert.assertNotNull(fileName);
+
+
+                InputStream stream = batchClient.fileOperations().getFileFromComputeNode(livePool.id(), nodeId, fileName);
+                String fileContent = IOUtils.toString(stream, "UTF-8");
+                Assert.assertEquals(fileContent, "hello\r\n");
+                stream.close();
+
+                String output = batchClient.protocolLayer().files().getFromComputeNodeAsync(livePool.id(), nodeId, fileName).map(new Func1<InputStream, String>() {
+                    @Override
+                    public String call(InputStream input) {
+                        try {
+                            return IOUtils.toString(input, "UTF-8");
+                        } catch (IOException e) {
+                            throw Exceptions.propagate(e);
+                        }
+                    }
+                }).toBlocking().single();
+                Assert.assertEquals(fileContent, "hello\r\n");
+
+                FileProperties properties = batchClient.fileOperations().getFilePropertiesFromComputeNode(livePool.id(), nodeId, fileName);
+                Assert.assertEquals(7, properties.contentLength());
+            } else {
+                throw new TimeoutException("Task did not complete within the specified timeout");
+            }
+        }
+        finally {
+            try {
+                batchClient.jobOperations().deleteJob(jobId);
+            }
+            catch (Exception e) {
+                // Ignore here
+            }
+        }
+    }
+}

--- a/src/test/java/com/microsoft/azure/batch/TaskTests.java
+++ b/src/test/java/com/microsoft/azure/batch/TaskTests.java
@@ -207,7 +207,7 @@ public class TaskTests  extends BatchTestBase {
 
     @Test
     public void testAddMultiTasks() throws Exception {
-        String jobId = getStringWithUserNamePrefix("-Job-" + (new Date()).toString().replace(' ', '-').replace(':', '-').replace('.', '-'));
+        String jobId = getStringWithUserNamePrefix("-Job1-" + (new Date()).toString().replace(' ', '-').replace(':', '-').replace('.', '-'));
 
         PoolInformation poolInfo = new PoolInformation();
         poolInfo.withPoolId(livePool.id());


### PR DESCRIPTION
1. Workaround runtime issue: [Azure/autorest-clientruntime-for-java] Fail to deserialize case insensitive headers (#155)
     Change the property name to lowercase
2. Workaround autorest issue: [Azure/autorest] Synchronous streaming is not supported in Java #1385
     Duplicate stream in the wrapper API
3. Fix authenticate issue and improve signing performance
     Should use getRawPath instead of getPath which decode the URL
4. Add FileTest