### PR TITLE
Fixes to javadoc to be lint clean.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,6 @@
           <target>1.7</target>
           <showWarnings>true</showWarnings>
           <showDeprecation>true</showDeprecation>
-          <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>
       </plugin>
 

--- a/src/main/java/com/microsoft/azure/batch/protocol/implementation/AccountsImpl.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/implementation/AccountsImpl.java
@@ -284,7 +284,7 @@ public class AccountsImpl implements Accounts {
     /**
      * Lists all node agent SKUs supported by the Azure Batch service.
      *
-    ServiceResponseWithHeaders<PageImpl<NodeAgentSku>, AccountListNodeAgentSkusHeaders> * @param accountListNodeAgentSkusOptions Additional parameters for the operation
+     * @param accountListNodeAgentSkusOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;NodeAgentSku&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -539,8 +539,8 @@ public class AccountsImpl implements Accounts {
     /**
      * Lists all node agent SKUs supported by the Azure Batch service.
      *
-    ServiceResponseWithHeaders<PageImpl<NodeAgentSku>, AccountListNodeAgentSkusHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<NodeAgentSku>, AccountListNodeAgentSkusHeaders> * @param accountListNodeAgentSkusNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param accountListNodeAgentSkusNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;NodeAgentSku&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */

--- a/src/main/java/com/microsoft/azure/batch/protocol/implementation/ApplicationsImpl.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/implementation/ApplicationsImpl.java
@@ -301,7 +301,7 @@ public class ApplicationsImpl implements Applications {
      * Lists all of the applications available in the specified account.
      * This operation returns only applications and versions that are available for use on compute nodes; that is, that can be used in an application package reference. For administrator information about applications and versions that are not yet available to compute nodes, use the Azure portal or the Azure Resource Manager API.
      *
-    ServiceResponseWithHeaders<PageImpl<ApplicationSummary>, ApplicationListHeaders> * @param applicationListOptions Additional parameters for the operation
+     * @param applicationListOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;ApplicationSummary&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -749,8 +749,8 @@ public class ApplicationsImpl implements Applications {
      * Lists all of the applications available in the specified account.
      * This operation returns only applications and versions that are available for use on compute nodes; that is, that can be used in an application package reference. For administrator information about applications and versions that are not yet available to compute nodes, use the Azure portal or the Azure Resource Manager API.
      *
-    ServiceResponseWithHeaders<PageImpl<ApplicationSummary>, ApplicationListHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<ApplicationSummary>, ApplicationListHeaders> * @param applicationListNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param applicationListNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;ApplicationSummary&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */

--- a/src/main/java/com/microsoft/azure/batch/protocol/implementation/CertificatesImpl.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/implementation/CertificatesImpl.java
@@ -494,7 +494,7 @@ public class CertificatesImpl implements Certificates {
     /**
      * Lists all of the certificates that have been added to the specified account.
      *
-    ServiceResponseWithHeaders<PageImpl<Certificate>, CertificateListHeaders> * @param certificateListOptions Additional parameters for the operation
+     * @param certificateListOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;Certificate&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -1349,8 +1349,8 @@ public class CertificatesImpl implements Certificates {
     /**
      * Lists all of the certificates that have been added to the specified account.
      *
-    ServiceResponseWithHeaders<PageImpl<Certificate>, CertificateListHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<Certificate>, CertificateListHeaders> * @param certificateListNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param certificateListNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;Certificate&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */

--- a/src/main/java/com/microsoft/azure/batch/protocol/implementation/ComputeNodesImpl.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/implementation/ComputeNodesImpl.java
@@ -2551,8 +2551,8 @@ public class ComputeNodesImpl implements ComputeNodes {
     /**
      * Lists the compute nodes in the specified pool.
      *
-    ServiceResponseWithHeaders<PageImpl<ComputeNode>, ComputeNodeListHeaders> * @param poolId The ID of the pool from which you want to list nodes.
-    ServiceResponseWithHeaders<PageImpl<ComputeNode>, ComputeNodeListHeaders> * @param computeNodeListOptions Additional parameters for the operation
+     * @param poolId The ID of the pool from which you want to list nodes.
+     * @param computeNodeListOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;ComputeNode&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -2814,8 +2814,8 @@ public class ComputeNodesImpl implements ComputeNodes {
     /**
      * Lists the compute nodes in the specified pool.
      *
-    ServiceResponseWithHeaders<PageImpl<ComputeNode>, ComputeNodeListHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<ComputeNode>, ComputeNodeListHeaders> * @param computeNodeListNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param computeNodeListNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;ComputeNode&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */

--- a/src/main/java/com/microsoft/azure/batch/protocol/implementation/FilesImpl.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/implementation/FilesImpl.java
@@ -1787,10 +1787,10 @@ public class FilesImpl implements Files {
     /**
      * Lists the files in a task's directory on its compute node.
      *
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromTaskHeaders> * @param jobId The ID of the job that contains the task.
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromTaskHeaders> * @param taskId The ID of the task whose files you want to list.
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromTaskHeaders> * @param recursive Whether to list children of the task directory. This parameter can be used in combination with the filter parameter to list specific type of files.
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromTaskHeaders> * @param fileListFromTaskOptions Additional parameters for the operation
+     * @param jobId The ID of the job that contains the task.
+     * @param taskId The ID of the task whose files you want to list.
+     * @param recursive Whether to list children of the task directory. This parameter can be used in combination with the filter parameter to list specific type of files.
+     * @param fileListFromTaskOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;NodeFile&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -2092,10 +2092,10 @@ public class FilesImpl implements Files {
     /**
      * Lists all of the files in task directories on the specified compute node.
      *
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromComputeNodeHeaders> * @param poolId The ID of the pool that contains the compute node.
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromComputeNodeHeaders> * @param nodeId The ID of the compute node whose files you want to list.
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromComputeNodeHeaders> * @param recursive Whether to list children of a directory.
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromComputeNodeHeaders> * @param fileListFromComputeNodeOptions Additional parameters for the operation
+     * @param poolId The ID of the pool that contains the compute node.
+     * @param nodeId The ID of the compute node whose files you want to list.
+     * @param recursive Whether to list children of a directory.
+     * @param fileListFromComputeNodeOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;NodeFile&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -2356,8 +2356,8 @@ public class FilesImpl implements Files {
     /**
      * Lists the files in a task's directory on its compute node.
      *
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromTaskHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromTaskHeaders> * @param fileListFromTaskNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param fileListFromTaskNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;NodeFile&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -2601,8 +2601,8 @@ public class FilesImpl implements Files {
     /**
      * Lists all of the files in task directories on the specified compute node.
      *
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromComputeNodeHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<NodeFile>, FileListFromComputeNodeHeaders> * @param fileListFromComputeNodeNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param fileListFromComputeNodeNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;NodeFile&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */

--- a/src/main/java/com/microsoft/azure/batch/protocol/implementation/JobSchedulesImpl.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/implementation/JobSchedulesImpl.java
@@ -2313,7 +2313,7 @@ public class JobSchedulesImpl implements JobSchedules {
     /**
      * Lists all of the job schedules in the specified account.
      *
-    ServiceResponseWithHeaders<PageImpl<CloudJobSchedule>, JobScheduleListHeaders> * @param jobScheduleListOptions Additional parameters for the operation
+     * @param jobScheduleListOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;CloudJobSchedule&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -2576,8 +2576,8 @@ public class JobSchedulesImpl implements JobSchedules {
     /**
      * Lists all of the job schedules in the specified account.
      *
-    ServiceResponseWithHeaders<PageImpl<CloudJobSchedule>, JobScheduleListHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<CloudJobSchedule>, JobScheduleListHeaders> * @param jobScheduleListNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param jobScheduleListNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;CloudJobSchedule&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */

--- a/src/main/java/com/microsoft/azure/batch/protocol/implementation/JobsImpl.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/implementation/JobsImpl.java
@@ -2381,7 +2381,7 @@ public class JobsImpl implements Jobs {
     /**
      * Lists all of the jobs in the specified account.
      *
-    ServiceResponseWithHeaders<PageImpl<CloudJob>, JobListHeaders> * @param jobListOptions Additional parameters for the operation
+     * @param jobListOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;CloudJob&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -2670,8 +2670,8 @@ public class JobsImpl implements Jobs {
     /**
      * Lists the jobs that have been created under the specified job schedule.
      *
-    ServiceResponseWithHeaders<PageImpl<CloudJob>, JobListFromJobScheduleHeaders> * @param jobScheduleId The ID of the job schedule from which you want to get a list of jobs.
-    ServiceResponseWithHeaders<PageImpl<CloudJob>, JobListFromJobScheduleHeaders> * @param jobListFromJobScheduleOptions Additional parameters for the operation
+     @param jobScheduleId The ID of the job schedule from which you want to get a list of jobs.
+     @param jobListFromJobScheduleOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;CloudJob&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -2972,8 +2972,8 @@ public class JobsImpl implements Jobs {
      * Lists the execution status of the Job Preparation and Job Release task for the specified job across the compute nodes where the job has run.
      * This API returns the Job Preparation and Job Release task status on all compute nodes that have run the Job Preparation or Job Release task. This includes nodes which have since been removed from the pool. If this API is invoked on a job which has no Job Preparation or Job Release task, the Batch service returns HTTP status code 409 (Conflict) with an error code of JobPreparationTaskNotSpecified.
      *
-    ServiceResponseWithHeaders<PageImpl<JobPreparationAndReleaseTaskExecutionInformation>, JobListPreparationAndReleaseTaskStatusHeaders> * @param jobId The ID of the job.
-    ServiceResponseWithHeaders<PageImpl<JobPreparationAndReleaseTaskExecutionInformation>, JobListPreparationAndReleaseTaskStatusHeaders> * @param jobListPreparationAndReleaseTaskStatusOptions Additional parameters for the operation
+     * @param jobId The ID of the job.
+     * @param jobListPreparationAndReleaseTaskStatusOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;JobPreparationAndReleaseTaskExecutionInformation&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -3422,8 +3422,8 @@ public class JobsImpl implements Jobs {
     /**
      * Lists all of the jobs in the specified account.
      *
-    ServiceResponseWithHeaders<PageImpl<CloudJob>, JobListHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<CloudJob>, JobListHeaders> * @param jobListNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param jobListNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;CloudJob&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -3667,8 +3667,8 @@ public class JobsImpl implements Jobs {
     /**
      * Lists the jobs that have been created under the specified job schedule.
      *
-    ServiceResponseWithHeaders<PageImpl<CloudJob>, JobListFromJobScheduleHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<CloudJob>, JobListFromJobScheduleHeaders> * @param jobListFromJobScheduleNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param jobListFromJobScheduleNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;CloudJob&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -3922,8 +3922,8 @@ public class JobsImpl implements Jobs {
      * Lists the execution status of the Job Preparation and Job Release task for the specified job across the compute nodes where the job has run.
      * This API returns the Job Preparation and Job Release task status on all compute nodes that have run the Job Preparation or Job Release task. This includes nodes which have since been removed from the pool. If this API is invoked on a job which has no Job Preparation or Job Release task, the Batch service returns HTTP status code 409 (Conflict) with an error code of JobPreparationTaskNotSpecified.
      *
-    ServiceResponseWithHeaders<PageImpl<JobPreparationAndReleaseTaskExecutionInformation>, JobListPreparationAndReleaseTaskStatusHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<JobPreparationAndReleaseTaskExecutionInformation>, JobListPreparationAndReleaseTaskStatusHeaders> * @param jobListPreparationAndReleaseTaskStatusNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param jobListPreparationAndReleaseTaskStatusNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;JobPreparationAndReleaseTaskExecutionInformation&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */

--- a/src/main/java/com/microsoft/azure/batch/protocol/implementation/PoolsImpl.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/implementation/PoolsImpl.java
@@ -409,7 +409,7 @@ public class PoolsImpl implements Pools {
      * Lists the usage metrics, aggregated by pool across individual time intervals, for the specified account.
      * If you do not specify a $filter clause including a poolId, the response includes all pools that existed in the account in the time range of the returned aggregation intervals. If you do not specify a $filter clause including a startTime or endTime these filters default to the start and end times of the last aggregation interval currently available; that is, only the last aggregation interval is returned.
      *
-    ServiceResponseWithHeaders<PageImpl<PoolUsageMetrics>, PoolListUsageMetricsHeaders> * @param poolListUsageMetricsOptions Additional parameters for the operation
+     * @param poolListUsageMetricsOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;PoolUsageMetrics&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -1046,7 +1046,7 @@ public class PoolsImpl implements Pools {
     /**
      * Lists all of the pools in the specified account.
      *
-    ServiceResponseWithHeaders<PageImpl<CloudPool>, PoolListHeaders> * @param poolListOptions Additional parameters for the operation
+     * @param poolListOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;CloudPool&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -3972,8 +3972,8 @@ public class PoolsImpl implements Pools {
      * Lists the usage metrics, aggregated by pool across individual time intervals, for the specified account.
      * If you do not specify a $filter clause including a poolId, the response includes all pools that existed in the account in the time range of the returned aggregation intervals. If you do not specify a $filter clause including a startTime or endTime these filters default to the start and end times of the last aggregation interval currently available; that is, only the last aggregation interval is returned.
      *
-    ServiceResponseWithHeaders<PageImpl<PoolUsageMetrics>, PoolListUsageMetricsHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<PoolUsageMetrics>, PoolListUsageMetricsHeaders> * @param poolListUsageMetricsNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param poolListUsageMetricsNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;PoolUsageMetrics&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -4217,8 +4217,8 @@ public class PoolsImpl implements Pools {
     /**
      * Lists all of the pools in the specified account.
      *
-    ServiceResponseWithHeaders<PageImpl<CloudPool>, PoolListHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<CloudPool>, PoolListHeaders> * @param poolListNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param poolListNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;CloudPool&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */

--- a/src/main/java/com/microsoft/azure/batch/protocol/implementation/TasksImpl.java
+++ b/src/main/java/com/microsoft/azure/batch/protocol/implementation/TasksImpl.java
@@ -569,8 +569,8 @@ public class TasksImpl implements Tasks {
      * Lists all of the tasks that are associated with the specified job.
      * For multi-instance tasks, information such as affinityId, executionInfo and nodeInfo refer to the primary task. Use the list subtasks API to retrieve information about subtasks.
      *
-    ServiceResponseWithHeaders<PageImpl<CloudTask>, TaskListHeaders> * @param jobId The ID of the job.
-    ServiceResponseWithHeaders<PageImpl<CloudTask>, TaskListHeaders> * @param taskListOptions Additional parameters for the operation
+     * @param jobId The ID of the job.
+     * @param taskListOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;CloudTask&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */
@@ -2448,8 +2448,8 @@ public class TasksImpl implements Tasks {
      * Lists all of the tasks that are associated with the specified job.
      * For multi-instance tasks, information such as affinityId, executionInfo and nodeInfo refer to the primary task. Use the list subtasks API to retrieve information about subtasks.
      *
-    ServiceResponseWithHeaders<PageImpl<CloudTask>, TaskListHeaders> * @param nextPageLink The NextLink from the previous successful call to List operation.
-    ServiceResponseWithHeaders<PageImpl<CloudTask>, TaskListHeaders> * @param taskListNextOptions Additional parameters for the operation
+     * @param nextPageLink The NextLink from the previous successful call to List operation.
+     * @param taskListNextOptions Additional parameters for the operation
      * @throws IllegalArgumentException thrown if parameters fail the validation
      * @return the PagedList&lt;CloudTask&gt; object wrapped in {@link ServiceResponseWithHeaders} if successful.
      */


### PR DESCRIPTION
This fixes a number of implementation classes that had invalid javadocs. Even though these may not be published APIs, it is important to ensure that the javadoc is valid so that the JavaDoc lint checker does not return errors. With this change there are no lint failures, and I have therefore taken the liberty of re-enabling the lint checking in the maven pom.